### PR TITLE
Remove TextArea export from main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 import "./index.css";
 
-export * from "./components/ui/Badge/Badge";
 export { Button, buttonVariants } from "./components/ui/Button/Button";
 export { Checkbox } from "./components/ui/Checkbox/Checkbox";
 export {
@@ -11,4 +10,3 @@ export { Modal } from "./components/ui/Modal/Modal";
 export { RadioGroup } from "./components/ui/RadioGroup/RadioGroup";
 export { RadioGroupItem } from "./components/ui/RadioGroup/RadioGroupItem/RadioGroupItem";
 export { Switch } from "./components/ui/Switch/Switch";
-export { TextArea } from "./components/ui/TextArea/TextArea";


### PR DESCRIPTION
Removed export of TextArea component from main.ts.

## Changes
_What has been done in this PR?_

- ...
- ...
- ...

## How to test
_Describe how to test the changes manually_

- ...
- ...
- ...

## Checklist
_Check if the code follows the standards_

- [ ] Follows [front-end standards](https://github.com/Generacja-Innowacja/gi-tech-standards/blob/main/docs/frontend/INDEX.md)
- [ ] No unused code / `console.log` / leftover comments
- [ ] Component is exported in the [main.ts file](https://github.com/Generacja-Innowacja/athena/blob/main/src/main.ts) (if applicable)
- [ ] Resolved merge conflicts (if applicable)
- [ ] Added / updated unit tests (if applicable)
- [ ] Added / updated storybook stories (if applicable)
