### PR TITLE
fix(input): resolve empty spacing and update styles for Tailwind v4 c…

### DIFF
--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -105,7 +105,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
         <div
           className={cn(
-            "flex items-center w-full min-h-[40px] px-3 bg-white border rounded-[24px] transition-all duration-300 ease",
+            "flex items-center w-full min-h-10 px-3 bg-white border rounded-3xl transition-all duration-300 ease",
             !isError &&
               !isDisabled &&
               "border-gi-primary/10 hover:border-gi-primary/33 focus-within:border-gi-primary/33 cursor-text",
@@ -118,7 +118,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           {LeftIcon ? (
             <div
               className={cn(
-                "flex-shrink-0 mr-2 flex items-center",
+                "shrink-0 mr-2 flex items-center",
                 isDisabled ? "opacity-30" : "text-gi-primary",
               )}
             >
@@ -192,7 +192,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             <div
               data-testid="right-icon-container"
               className={cn(
-                "flex-shrink-0 ml-2 flex items-center",
+                "shrink-0 ml-2 flex items-center",
                 isDisabled ? "opacity-30" : "text-gi-primary",
               )}
             >
@@ -200,9 +200,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             </div>
           ) : null}
         </div>
-
-        <div className="min-h-[20px]">
-          {secondaryText && !isDisabled ? (
+        {secondaryText && !isDisabled ? (
+          <div className="min-h-5">
             <p
               id={descriptionId}
               className={cn(
@@ -212,8 +211,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             >
               {secondaryText}
             </p>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
       </div>
     );
   },


### PR DESCRIPTION
## Changes

- Input Layout Optimization: Fixed the redundant bottom spacing by wrapping the secondary text (helper/error) in a conditional render. The container now only appears when there is actual content to display.
- Tailwind v4 Migration: Refactored hardcoded values into Tailwind v4 utility classes (changed min-h-[40px] to min-h-10, rounded-[24px] to rounded-3xl).

## How to test

- pace Check: Open the Default story for the Input component in Storybook. Verify that there is no empty gap below the input field when no helper text is provided.
- Validation Check: Toggle the isError state or add a helper text in Storybook controls to ensure the spacing appears correctly only when the text is visible.
- Style Verification: Inspect the input in the browser to confirm that Tailwind v4 classes (min-h-10, rounded-3xl) are correctly applied.

## Visual Preview

- **no helper added**
<img width="1677" height="1061" alt="Zrzut ekranu 2026-05-8 o 13 42 23" src="https://github.com/user-attachments/assets/27ac7201-126d-4c04-848c-a05323a3b492" />

- **helper added**
<img width="1678" height="1008" alt="Zrzut ekranu 2026-05-8 o 13 41 34" src="https://github.com/user-attachments/assets/eb1e5b82-f3fc-4549-b8a7-6c802c0a3735" />

- **The min-h-5 div is now hidden by default. It only appears when helper text is added. This fixes the empty space bug.**


## Checklist

- [x] Follows [front-end standards](https://github.com/Generacja-Innowacja/gi-tech-standards/blob/main/docs/frontend/INDEX.md)
- [x] No unused code / `console.log` / leftover comments
- [x] Component is exported in the [main.ts file](https://github.com/Generacja-Innowacja/athena/blob/main/src/main.ts) (if applicable)
- [x] Resolved merge conflicts (if applicable)
- [ ] Added / updated unit tests (if applicable)
- [x] Added / updated storybook stories (if applicable)
