### PR TITLE
fix: update exports in package.json to streamline CSS source export

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,88 +80,9 @@
   "exports": {
     ".": {
       "import": "./dist/athena.js",
-      "types": "./dist/main.d.ts"
+      "types": "./dist/index.d.ts"
     },
-    "./avatar": {
-      "import": "./dist/avatar.js",
-      "types": "./dist/components/ui/Avatar/Avatar.d.ts"
-    },
-    "./badge": {
-      "import": "./dist/badge.js",
-      "types": "./dist/components/ui/Badge/Badge.d.ts"
-    },
-    "./button": {
-      "import": "./dist/button.js",
-      "types": "./dist/components/ui/Button/Button.d.ts"
-    },
-    "./button-select": {
-      "import": "./dist/button-select.js",
-      "types": "./dist/components/ui/ButtonSelect/ButtonSelect.d.ts"
-    },
-    "./checkbox": {
-      "import": "./dist/checkbox.js",
-      "types": "./dist/components/ui/Checkbox/Checkbox.d.ts"
-    },
-    "./info-message": {
-      "import": "./dist/info-message.js",
-      "types": "./dist/components/ui/InfoMessage/InfoMessage.d.ts"
-    },
-    "./input": {
-      "import": "./dist/input.js",
-      "types": "./dist/components/ui/Input/Input.d.ts"
-    },
-    "./modal": {
-      "import": "./dist/modal.js",
-      "types": "./dist/components/ui/Modal/Modal.d.ts"
-    },
-    "./pagination": {
-      "import": "./dist/pagination.js",
-      "types": "./dist/components/ui/Pagination/Pagination.d.ts"
-    },
-    "./progress-bar": {
-      "import": "./dist/progress-bar.js",
-      "types": "./dist/components/ui/ProgressBar/ProgressBar.d.ts"
-    },
-    "./radio-group": {
-      "import": "./dist/radio-group.js",
-      "types": "./dist/components/ui/RadioGroup/RadioGroup.d.ts"
-    },
-    "./radio-group-item": {
-      "import": "./dist/radio-group-item.js",
-      "types": "./dist/components/ui/RadioGroup/RadioGroupItem/RadioGroupItem.d.ts"
-    },
-    "./section": {
-      "import": "./dist/section.js",
-      "types": "./dist/components/ui/Section/Section.d.ts"
-    },
-    "./action-list": {
-      "import": "./dist/action-list.js",
-      "types": "./dist/components/ui/Select/ActionList/ActionList.d.ts"
-    },
-    "./select": {
-      "import": "./dist/select.js",
-      "types": "./dist/components/ui/Select/Select.d.ts"
-    },
-    "./switch": {
-      "import": "./dist/switch.js",
-      "types": "./dist/components/ui/Switch/Switch.d.ts"
-    },
-    "./table": {
-      "import": "./dist/table.js",
-      "types": "./dist/components/ui/Table/Table.d.ts"
-    },
-    "./tabs": {
-      "import": "./dist/tabs.js",
-      "types": "./dist/components/ui/Tabs/Tabs.d.ts"
-    },
-    "./textarea": {
-      "import": "./dist/textarea.js",
-      "types": "./dist/components/ui/TextArea/TextArea.d.ts"
-    },
-    "./tooltip": {
-      "import": "./dist/tooltip.js",
-      "types": "./dist/components/ui/Tooltip/Tooltip.d.ts"
-    },
+    "./athena.css": "./dist/athena.css",
     "./css": "./src/index.css"
   }
 }


### PR DESCRIPTION
## Changes
_What has been done in this PR?_

- Added a new package export `"./css": "./src/index.css"` so host apps can import raw Athena styles via `@gi/athena/css`

## How to test
_Describe how to test the changes manually_

- Run yarn install
- yarn test
- In a host app (e.g. mypolitics-app), update the CSS import in `root.tsx` and Storybook `preview.tsx`:
  // before
  import "@gi/athena/athena.css";
  // after
  import "@gi/athena/css";

## Visual Preview
_How your change looks_

Every color from Athena is loaded in component created for testing
<img width="500" height="80" alt="image" src="https://github.com/user-attachments/assets/df728e4f-028e-4d3b-988a-e3e06c3dadf5" />

## Checklist
_Check if the code follows the standards_

- [x] Follows [front-end standards](https://github.com/Generacja-Innowacja/gi-tech-standards/blob/main/docs/frontend/INDEX.md)
- [x] No unused code / `console.log` / leftover comments
- [ ] Component is exported in the [main.ts file](https://github.com/Generacja-Innowacja/athena/blob/main/src/main.ts) (if applicable)
- [ ] Resolved merge conflicts (if applicable)
- [ ] Added / updated unit tests (if applicable)
- [ ] Added / updated storybook stories (if applicable)
