### PR TITLE
fix(css): update CSS export path and standardize color variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,7 @@
     ]
   },
   "exports": {
-    ".": {
-      "import": "./dist/athena.js",
-      "types": "./dist/index.d.ts"
-    },
+    ".": "./src/main.ts",
     "./athena.css": "./src/index.css"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
       "import": "./dist/athena.js",
       "types": "./dist/index.d.ts"
     },
-    "./athena.css": "./dist/athena.css"
-    }
+    "./athena.css": "./src/index.css"
+  }
 }

--- a/src/components/ui/Avatar/Avatar.tsx
+++ b/src/components/ui/Avatar/Avatar.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useEffect, useState } from "react";
-import Female from "@/assets/icons/female-icon.svg";
-import Male from "@/assets/icons/male-icon.svg";
-import { cn } from "@/lib/utils";
+import Female from "../../../assets/icons/female-icon.svg";
+import Male from "../../../assets/icons/male-icon.svg";
+import { cn } from "../../../lib/utils";
 import { getInitials } from "./Avatar.methods";
 import { type AvatarProps, avatarVariants } from "./Avatar.types";
 

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -1,10 +1,10 @@
 import { forwardRef, useMemo } from "react";
-import CheckIcon from "@/assets/icons/check-icon.svg";
-import DismissCircle from "@/assets/icons/dismiss-circle-icon.svg";
-import InfoIcon from "@/assets/icons/info-icon.svg";
-import WarningIcon from "@/assets/icons/warning-icon.svg";
-import XIcon from "@/assets/icons/x-icon.svg";
-import { cn } from "@/lib/utils";
+import CheckIcon from "../../../assets/icons/check-icon.svg";
+import DismissCircle from "../../../assets/icons/dismiss-circle-icon.svg";
+import InfoIcon from "../../../assets/icons/info-icon.svg";
+import WarningIcon from "../../../assets/icons/warning-icon.svg";
+import XIcon from "../../../assets/icons/x-icon.svg";
+import { cn } from "../../../lib/utils";
 import { type BadgeProps, badgeVariants } from "./Badge.types";
 
 const typeIconMap = {

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -7,8 +7,8 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
-import LoadingSpinner from "@/assets/icons/loading-spinner.svg";
-import { cn } from "@/lib/utils";
+import LoadingSpinner from "../../../assets/icons/loading-spinner.svg";
+import { cn } from "../../../lib/utils";
 import { type ButtonProps, buttonVariants } from "./Button.types";
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/src/components/ui/Button/Button.types.tsx
+++ b/src/components/ui/Button/Button.types.tsx
@@ -37,7 +37,7 @@ export const buttonVariants = cva(
         small: "h-8 px-3 text-xs gap-1.5 has-[>svg]:px-2.5",
         regular: "h-10 px-4 py-2 has-[>svg]:px-3",
         "ngo-small": "h-8 px-3 text-xs gap-2 has-[>svg]:px-3",
-        "ngo-regular": "h-10 px-4 py-2 has-[>svg]:px-4"
+        "ngo-regular": "h-10 px-4 py-2 has-[>svg]:px-4",
       },
       isIconButton: {
         true: "p-0",
@@ -50,7 +50,7 @@ export const buttonVariants = cva(
         className:
           "bg-gi-primary text-white hover:bg-gi-primary-hover data-[disabled=true]:bg-gi-gray data-[disabled=true]:text-white",
       },
-            {
+      {
         type: "primary",
         variant: "ngoPrimary",
         className:

--- a/src/components/ui/Checkbox/Checkbox.tsx
+++ b/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { Indicator, Root } from "@radix-ui/react-checkbox";
 import { useId } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import type { CheckboxProps } from "./Checkbox.types";
 
 export const Checkbox = ({

--- a/src/components/ui/InfoMessage/InfoMessage.tsx
+++ b/src/components/ui/InfoMessage/InfoMessage.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useMemo } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import {
   type InfoMessageProps,
   infoMessageIconVariants,

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import { getOverlayContent } from "./Input.methods";
 import type { InputProps } from "./Input.types";
 

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import {
   footerVariants,
   headerVariants,

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useMemo } from "react";
-import ChevronLeftIcon from "@/assets/icons/chevron-left-icon.svg";
-import ChevronRightIcon from "@/assets/icons/chevron-right-icon.svg";
-import { cn } from "@/lib/utils";
+import ChevronLeftIcon from "../../../assets/icons/chevron-left-icon.svg";
+import ChevronRightIcon from "../../../assets/icons/chevron-right-icon.svg";
+import { cn } from "../../../lib/utils";
 import { Button } from "../Button/Button";
 import { generatePaginationRange } from "./Pagination.methods";
 import type { PaginationProps } from "./Pagination.types";

--- a/src/components/ui/ProgressBar/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import {
   type ProgressBarProps,
   progressBarFillVariants,

--- a/src/components/ui/RadioGroup/RadioGroup.tsx
+++ b/src/components/ui/RadioGroup/RadioGroup.tsx
@@ -4,7 +4,7 @@ import {
   type ComponentRef,
   forwardRef,
 } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 
 export const RadioGroup = forwardRef<
   ComponentRef<typeof Root>,

--- a/src/components/ui/RadioGroup/RadioGroupItem/RadioGroupItem.tsx
+++ b/src/components/ui/RadioGroup/RadioGroupItem/RadioGroupItem.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentRef,
   forwardRef,
 } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../../lib/utils";
 
 export const RadioGroupItem = forwardRef<
   ComponentRef<typeof Item>,

--- a/src/components/ui/Section/Section.tsx
+++ b/src/components/ui/Section/Section.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useId } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import type { SectionProps } from "./Section.types";
 
 export const Section = forwardRef<HTMLElement, SectionProps>(

--- a/src/components/ui/Select/ActionList/ActionList.methods.tsx
+++ b/src/components/ui/Select/ActionList/ActionList.methods.tsx
@@ -7,7 +7,7 @@ import {
 } from "@radix-ui/react-dropdown-menu";
 import { type ComponentProps } from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../../../lib/utils";
 
 export function DropdownMenu({ ...props }: ComponentProps<typeof Root>) {
   return <Root data-slot="dropdown-menu" {...props} />;

--- a/src/components/ui/Select/ActionList/ActionList.tsx
+++ b/src/components/ui/Select/ActionList/ActionList.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../../lib/utils";
 import { DropdownMenuItem } from "./ActionList.methods";
 import type { ActionListProps } from "./ActionList.types";
 

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useCallback, useRef, useState } from "react";
-import ChevronDown from "@/assets/icons/chevron-down-icon.svg";
-import { cn } from "@/lib/utils";
+import ChevronDown from "../../../assets/icons/chevron-down-icon.svg";
+import { cn } from "../../../lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/components/ui/Switch/Switch.tsx
+++ b/src/components/ui/Switch/Switch.tsx
@@ -4,7 +4,7 @@ import {
   type ElementRef,
   forwardRef,
 } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 
 export const Switch = forwardRef<
   ElementRef<typeof Root>,

--- a/src/components/ui/Table/Table.tsx
+++ b/src/components/ui/Table/Table.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import { Badge } from "../Badge/Badge";
 import { Checkbox } from "../Checkbox/Checkbox";
 import { Pagination } from "../Pagination/Pagination";

--- a/src/components/ui/TextArea/TextArea.tsx
+++ b/src/components/ui/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import { cva } from "class-variance-authority";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 
 const TextAreaVariants = cva(
   "px-3 py-2 w-[346px] h-[122px] text-gi-primary rounded-3xl border-[1px] ",

--- a/src/components/ui/Tooltip/Tooltip.methods.tsx
+++ b/src/components/ui/Tooltip/Tooltip.methods.tsx
@@ -7,7 +7,7 @@ import {
   Trigger,
 } from "@radix-ui/react-tooltip";
 import { type ComponentProps } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 
 export const TooltipProvider = ({
   delayDuration = 0,

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../../lib/utils";
 import {
   TooltipContent,
   TooltipProvider,

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@source "../src/**/*.{ts,tsx}";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
@@ -39,35 +41,32 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
-}
-
-@theme {
-  --color-gi-dark-primary: #001e24;
-  --color-gi-primary: #004554;
-  --color-gi-primary-hover: #003743;
-  --color-gi-light-primary: #005669;
-  --color-gi-secondary: #007994;
-  --color-gi-secondary-hover: #006176;
-  --color-gi-dark-gray: #324c52;
-  --color-gi-gray: #98a5a8;
-  --color-gi-gray-hover: #7a8486;
-  --color-gi-dark-ash: #d3d9da;
-  --color-gi-ash: #ecf0f2;
-  --color-gi-ash-hover: #bdc0c2;
-  --color-gi-red: #e43235;
-  --color-gi-red-hover: #b6282a;
-  --color-gi-green: #489c21;
-  --color-gi-green-hover: #3a7d1a;
-  --color-gi-orange: #e19a26;
-  --color-gi-orange-hover: #b47b1e;
-  --color-gi-blue: #3279e4;
-  --color-gi-blue-hover: #2861b6;
-  --color-gi-navy: #2c4160;
-  --color-gi-navy-hover: #22324a;
-  --color-gi-blue-soft: #4f72a5;
-  --color-gi-blue-lightest: #ddebff;
-  --color-gi-light-gray: #f0f2f4;
-  --color-gi-light-gray-dark: #dce0e6;
+  --color-gi-dark-primary: var(--gi-dark-primary);
+  --color-gi-primary: var(--gi-primary);
+  --color-gi-primary-hover: var(--gi-primary-hover);
+  --color-gi-light-primary: var(--gi-light-primary);
+  --color-gi-secondary: var(--gi-secondary);
+  --color-gi-secondary-hover: var(--gi-secondary-hover);
+  --color-gi-dark-gray: var(--gi-dark-gray);
+  --color-gi-gray: var(--gi-gray);
+  --color-gi-gray-hover: var(--gi-gray-hover);
+  --color-gi-dark-ash: var(--gi-dark-ash);
+  --color-gi-ash: var(--gi-ash);
+  --color-gi-ash-hover: var(--gi-ash-hover);
+  --color-gi-red: var(--gi-red);
+  --color-gi-red-hover: var(--gi-red-hover);
+  --color-gi-green: var(--gi-green);
+  --color-gi-green-hover: var(--gi-green-hover);
+  --color-gi-orange: var(--gi-orange);
+  --color-gi-orange-hover: var(--gi-orange-hover);
+  --color-gi-blue: var(--gi-blue);
+  --color-gi-blue-hover: var(--gi-blue-hover);
+  --color-gi-navy: var(--gi-navy);
+  --color-gi-navy-hover: var(--gi-navy-hover);
+  --color-gi-blue-soft: var(--gi-blue-soft);
+  --color-gi-blue-lightest: var(--gi-blue-lightest);
+  --color-gi-light-gray: var(--gi-light-gray);
+  --color-gi-light-gray-dark: var(--gi-light-gray-dark);
 }
 
 :root {
@@ -103,6 +102,32 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --gi-dark-primary: oklch(0.2159 0.0378 213.04);
+  --gi-primary: oklch(0.360529 0.06495 218.4126);
+  --gi-primary-hover: oklch(0.3108 0.0557 217.61);
+  --gi-light-primary: oklch(0.4189 0.076 219.48);
+  --gi-secondary: oklch(0.5332 0.0975 220.61);
+  --gi-secondary-hover: oklch(0.455353 0.08256 219.3898);
+  --gi-dark-gray: oklch(0.398 0.0331 213.7);
+  --gi-gray: oklch(0.7126 0.0154 213.12);
+  --gi-gray-hover: oklch(0.6057 0.0122 211.04);
+  --gi-dark-ash: oklch(0.881 0.0067 208.78);
+  --gi-ash: oklch(0.9527 0.0051 228.82);
+  --gi-ash-hover: oklch(0.806 0.0044 236.51);
+  --gi-red: oklch(0.601 0.2132 25.79);
+  --gi-red-hover: oklch(0.5097 0.1783 25.68);
+  --gi-green: oklch(0.6166 0.1744 138.04);
+  --gi-green-hover: oklch(0.5258 0.1468 137.82);
+  --gi-orange: oklch(0.7387 0.1464 73.45);
+  --gi-orange-hover: oklch(0.6265 0.1232 73.69);
+  --gi-blue: oklch(0.5891 0.1775 258.78);
+  --gi-blue-hover: oklch(0.5021 0.1473 258.57);
+  --gi-navy: oklch(0.3726 0.0599 257.97);
+  --gi-navy-hover: oklch(0.3149 0.0483 258.28);
+  --gi-blue-soft: oklch(0.548 0.0897 257.71);
+  --gi-blue-lightest: oklch(0.9357 0.031 257.23);
+  --gi-light-gray: oklch(0.9602 0.0034 247.86);
+  --gi-light-gray-dark: oklch(0.9054 0.0092 258.34);
 }
 
 .dark {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,3 @@
-import "./index.css";
-
 export { Avatar } from "./components/ui/Avatar/Avatar";
 export { Badge } from "./components/ui/Badge/Badge";
 export { Button } from "./components/ui/Button/Button";


### PR DESCRIPTION
## Changes
_What has been done in this PR?_

- Fixed Athena package exports
- Updated Athena color tokens in `src/index.css` to expose GI colors through CSS variables and Tailwind theme tokens.
- Added Tailwind `@source` for Athena source files so classes used by Athena components are included when consumed by apps.
- Replaced Athena runtime `@/...` imports with relative imports so apps can consume Athena source files without needing Athena’s local alias config.

## How to test
_Describe how to test the changes manually_

- Run the consuming app and verify Athena components render with correct GI colors.

## Visual Preview
_How your change looks_

## Checklist
_Check if the code follows the standards_

- [ ] Follows [front-end standards](https://github.com/Generacja-Innowacja/gi-tech-standards/blob/main/docs/frontend/INDEX.md)
- [ ] No unused code / `console.log` / leftover comments
- [ ] Component is exported in the [main.ts file](https://github.com/Generacja-Innowacja/athena/blob/main/src/main.ts) (if applicable)
- [ ] Resolved merge conflicts (if applicable)
- [ ] Added / updated unit tests (if applicable)
- [ ] Added / updated storybook stories (if applicable)