### PR TITLE
ci: add Storybook build to frontend CI and pin Yarn v1

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -35,6 +35,16 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Build Storybook
+        run: yarn storybook:build
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook-build
+          if-no-files-found: error
+          path: storybook-static
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "license": "proprietary",
+  "packageManager": "yarn@1.22.22",
   "main": "index.js",
   "author": "generacja-innowacja",
   "scripts": {


### PR DESCRIPTION
### Motivation
- Ensure Storybook is verified as part of the frontend CI so pull requests fail when Storybook cannot build and a Storybook build artifact is available for inspection.
- Match CI environment to the repository lockfile by pinning the package manager to Yarn v1 to avoid install inconsistencies.

### Description
- Added a `Build Storybook` step to `.github/workflows/build-frontend.yml` that runs `yarn storybook:build` and added an artifact upload step to publish the generated `storybook-static` directory.
- Left existing build and artifact upload for the production `dist` untouched so both build artifacts are produced.
- Added `"packageManager": "yarn@1.22.22"` to `package.json` to explicitly pin the project to Yarn v1 to align with the repo's lockfile.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"` which completed successfully.
- Parsed workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-frontend.yml'); puts 'workflow yaml ok'"` which completed successfully.
- Ran `git diff --check` to verify whitespace/format issues and fixed CRLF/trailing whitespace; check reported clean afterwards.
- Attempted `yarn storybook:build` locally but it could not complete in this environment because Corepack was blocked from downloading Yarn 1.22.22 due to the proxy/registry policy, so Storybook build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343bf49a7883248fe71f87d60d68d3)