### PR TITLE
chore: clean up Biome scripts

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -92,5 +92,5 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Run lint
-        run: yarn run lint
+      - name: Run Biome check
+        run: yarn run check

--- a/package.json
+++ b/package.json
@@ -4,17 +4,20 @@
   "version": "0.0.0",
   "type": "module",
   "license": "proprietary",
+  "packageManager": "yarn@1.22.22",
   "main": "index.js",
   "author": "generacja-innowacja",
   "scripts": {
     "build": "vite build",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "lint": "npx @biomejs/biome lint",
-    "lint:fix": "npx @biomejs/biome check --write",
+    "lint": "biome lint",
+    "lint:fix": "biome check --write",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "format:check": "biome format --check",
+    "check": "biome check"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
### Motivation
- Ensure the repo uses the local `biome` binary (instead of `npx`) and has explicit scripts for format/check so tooling is consistent across local runs and CI.
- Pin the package manager to a Yarn release compatible with the lockfile to avoid Corepack/Yarn mismatches when installing dependencies.
- Make the frontend CI lint job run the project's shared check command so CI and local runs are aligned.

### Description
- Add `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343bed399c83248913533141c75a6d)