### PR TITLE
Add TypeScript typecheck script and run typecheck in frontend CI

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Typecheck
+        run: yarn typecheck
+
       - name: Build
         run: yarn build
 
@@ -61,6 +64,9 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Typecheck
+        run: yarn typecheck
 
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "generacja-innowacja",
   "scripts": {
     "build": "vite build",
+    "typecheck": "tsc -b",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "npx @biomejs/biome lint",

--- a/src/components/ui/Select/ActionList/ActionList.test.tsx
+++ b/src/components/ui/Select/ActionList/ActionList.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React, { createRef } from "react";
+import { createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ActionList } from "./ActionList";
 import { DropdownMenu, DropdownMenuContent } from "./ActionList.methods";


### PR DESCRIPTION
### Motivation
- Enforce TypeScript correctness during CI to catch type errors early in the frontend pipeline.
- Ensure the codebase is compatible with stricter `tsc` checks by removing unused imports that would fail typechecking.

### Description
- Add a `typecheck` npm script that runs `tsc -b` by updating `package.json`.
- Insert a `Typecheck` step that runs `yarn typecheck` before the `Build` step in both the `build` and `unit` jobs of `.github/workflows/build-frontend.yml`.
- Fix a test file by removing an unused default `React` import in `src/components/ui/Select/ActionList/ActionList.test.tsx` so `tsc` does not report `TS6133`.

### Testing
- Ran `yarn typecheck`, which initially failed with `TS6133` due to an unused `React` import. 
- After removing the unused import, `yarn typecheck` was run again and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343be8899483249d2114f442f44954)