### PR TITLE
Add release automation and npm package metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: yarn
+          cache-dependency-path: yarn.lock
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build package
+        run: yarn build
+
+      - name: Prepare release version
+        run: yarn release:version
+
+      - name: Publish package
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -180,3 +180,18 @@ yarn storybook:build  # Build Storybook for production deployment
 - [Vitest Documentation](https://vitest.dev/) - Vitest testing framework documentation
 - [BiomeJS Documentation](https://biomejs.dev/) - BiomeJS linter and formatter documentation
 - [Storybook Documentation](https://storybook.js.org/) - Storybook component development and visual testing documentation
+
+## Installing from npm
+
+Athena is published as `@gi-org-pl/athena` whenever changes are pushed to the `main` branch.
+
+```bash
+npm install @gi-org-pl/athena
+```
+
+Import components and styles from the package instead of importing directly from this repository:
+
+```tsx
+import { Button } from "@gi-org-pl/athena";
+import "@gi-org-pl/athena/athena.css";
+```

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "athena",
-  "private": true,
+  "name": "@gi-org-pl/athena",
+  "private": false,
   "version": "0.0.0",
   "type": "module",
-  "license": "proprietary",
-  "main": "index.js",
+  "license": "UNLICENSED",
+  "main": "./dist/athena.js",
   "author": "generacja-innowacja",
   "scripts": {
     "build": "vite build",
@@ -14,7 +14,8 @@
     "lint:fix": "npx @biomejs/biome check --write",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "release:version": "node scripts/set-release-version.mjs"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -78,7 +79,28 @@
     ]
   },
   "exports": {
-    ".": "./src/main.ts",
-    "./athena.css": "./src/index.css"
-  }
+    ".": {
+      "types": "./dist/main.d.ts",
+      "import": "./dist/athena.js"
+    },
+    "./athena.css": "./dist/athena.css"
+  },
+  "description": "Generacja Innowacja React component library.",
+  "module": "./dist/athena.js",
+  "types": "./dist/main.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gi-org-pl/athena.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gi-org-pl/athena/issues"
+  },
+  "homepage": "https://github.com/gi-org-pl/athena#readme"
 }

--- a/scripts/set-release-version.mjs
+++ b/scripts/set-release-version.mjs
@@ -1,0 +1,15 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const packageJsonPath = new URL("../package.json", import.meta.url);
+const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+const runNumber = process.env.GITHUB_RUN_NUMBER;
+const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? "1";
+
+if (!runNumber) {
+  throw new Error("GITHUB_RUN_NUMBER is required to create a release version.");
+}
+
+packageJson.version = `0.0.0-main.${runNumber}.${runAttempt}`;
+
+await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+console.log(`Prepared ${packageJson.name}@${packageJson.version}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import "./index.css";
+
 export { Avatar } from "./components/ui/Avatar/Avatar";
 export { Badge } from "./components/ui/Badge/Badge";
 export { Button } from "./components/ui/Button/Button";


### PR DESCRIPTION
### Motivation
- Automate publishing the built library to npm on pushes to `main` and provide a predictable package layout and versioning for consumers.
- Ensure the built JS, type declarations and CSS are exported from the package so consumers can import components and styles from `@gi-org-pl/athena`.

### Description
- Add GitHub Actions workflow `.github/workflows/release.yml` that installs deps, builds, prepares a release version, and runs `npm publish` using `NODE_AUTH_TOKEN` on pushes to `main`.
- Add `scripts/set-release-version.mjs` which sets `package.json` to a unique `0.0.0-main.<run>.<attempt>` version using GitHub Actions run metadata.
- Update `package.json` to publish as `@gi-org-pl/athena`, expose `./dist/athena.js`, `./dist/main.d.ts` and `./dist/athena.css` via `exports`, add files/publishConfig/repository metadata, and add the `release:version` script.
- Include the compiled CSS in the library entry by importing `./index.css` in `src/main.ts` and document installation/usage in `README.md`.

### Testing
- Ran `npm run build` which produced `dist/athena.js`, `dist/athena.css`, and `dist/main.d.ts` (succeeded).
- Ran lint via `npm run lint` (calls `npx @biomejs/biome lint`) and it completed with no issues (succeeded).
- Ran `GITHUB_RUN_NUMBER=123 GITHUB_RUN_ATTEMPT=2 npm run release:version` to verify version generation and it printed the prepared package version (succeeded).
- Ran `npm pack --dry-run` to validate the packaged files list and tarball metadata (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343c5126888324bc1bbd4a1be4992d)