### PR TITLE
Clean up package contract for library consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,35 @@ yarn storybook:build  # Build Storybook for production
 
 5. Export new component in the [main.ts file](src\main.ts)
 
+
+## Consuming the package
+
+Athena is published as a React component library. Install it alongside React and React DOM in the consuming application:
+
+```bash
+yarn add athena react react-dom
+```
+
+Import components from the package root and include the bundled stylesheet once in your application entry point:
+
+```tsx
+import { Button } from "athena";
+import "athena/athena.css";
+
+export function Example() {
+  return <Button>Save</Button>;
+}
+```
+
+The package exposes ESM, CommonJS, TypeScript declaration, and CSS entry points from `dist` after running `yarn build`:
+
+- `athena` resolves to `dist/athena.js` for ESM consumers.
+- `athena` resolves to `dist/athena.umd.cjs` for CommonJS consumers.
+- TypeScript resolves declarations from `dist/index.d.ts`.
+- `athena/athena.css` resolves to `dist/athena.css`.
+
+React and React DOM are peer dependencies, so consuming applications must provide compatible versions. They remain in this repository's dev dependencies for local development, testing, and Storybook.
+
 ## Build
 
 This project uses Vite for building the library. The build process generates optimized static assets for production deployment.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "athena",
-  "private": true,
   "version": "0.0.0",
   "type": "module",
   "license": "proprietary",
-  "main": "index.js",
+  "main": "./dist/athena.umd.cjs",
   "author": "generacja-innowacja",
   "scripts": {
     "build": "vite build",
@@ -28,8 +27,6 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.554.0",
     "radix-ui": "^1.4.3",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17"
   },
@@ -66,7 +63,9 @@
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-svgr": "^4.5.0",
     "vitest": "^4.0.10",
-    "vitest-browser-react": "^2.0.2"
+    "vitest-browser-react": "^2.0.2",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "engines": {
     "node": ">=24",
@@ -78,7 +77,23 @@
     ]
   },
   "exports": {
-    ".": "./src/main.ts",
-    "./athena.css": "./src/index.css"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/athena.js",
+      "require": "./dist/athena.umd.cjs"
+    },
+    "./athena.css": "./dist/athena.css"
+  },
+  "module": "./dist/athena.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "peerDependencies": {
+    "react": ">=18.0.0 || >=19.0.0",
+    "react-dom": ">=18.0.0 || >=19.0.0"
   }
 }

--- a/src/components/ui/Select/ActionList/ActionList.test.tsx
+++ b/src/components/ui/Select/ActionList/ActionList.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React, { createRef } from "react";
+import { createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ActionList } from "./ActionList";
 import { DropdownMenu, DropdownMenuContent } from "./ActionList.methods";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import "./index.css";
+
 export { Avatar } from "./components/ui/Avatar/Avatar";
 export { Badge } from "./components/ui/Badge/Badge";
 export { Button } from "./components/ui/Button/Button";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,17 +34,21 @@ export default defineConfig({
     copyPublicDir: false,
     lib: {
       entry: path.resolve(__dirname, "src/main.ts"),
-      formats: ["es"],
+      formats: ["es", "umd"],
+      name: "Athena",
+      fileName: (format) => (format === "es" ? "athena.js" : "athena.umd.cjs"),
     },
     rollupOptions: {
-      external: [
-        "react",
-        "react/jsx-runtime",
-        "tailwindcss",
-        "tailwind-merge",
-        "react-dom",
-        "@tailwindcss/vite",
-      ],
+      external: ["react", "react/jsx-runtime", "react-dom"],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+          "react/jsx-runtime": "ReactJSXRuntime",
+        },
+        assetFileNames: (assetInfo) =>
+          assetInfo.names.includes("style.css") ? "athena.css" : "[name][extname]",
+      },
     },
   },
 });


### PR DESCRIPTION
### Motivation
- Prepare the project to be consumed as a proper npm package by making build outputs the canonical package entry points and treating React as a peer dependency. 
- Ensure the built `dist` artifacts (JS, UMD/CJS, CSS, and types) are produced with stable filenames and are referenced from `package.json`/`exports` so consumers can import the library cleanly.

### Description
- Move `react` and `react-dom` out of runtime `dependencies` into `devDependencies` and add them to `peerDependencies` in `package.json`, and set `main`, `module`, `types`, `files`, `exports`, and `sideEffects` to point at `dist` artifacts. 
- Update `vite.config.ts` to emit both `es` and `umd` builds with a stable `fileName`, add `name: "Athena"`, externalize react/react-dom/`react/jsx-runtime`, and configure `output.globals` and `assetFileNames` so CSS and bundles are correctly named. 
- Import the library stylesheet in the bundle entry by adding `import "./index.css";` to `src/main.ts` so `dist/athena.css` is generated. 
- Remove an unused default `React` import from `src/components/ui/Select/ActionList/ActionList.test.tsx` to silence TypeScript/`dts` noise. 
- Add a new section to `README.md` documenting how consuming applications should install and import the package (`athena`, `athena/athena.css`) and what entrypoints are provided.

### Testing
- Ran `npx vite build` to produce `dist` artifacts and declaration files, and the build completed successfully. 
- Ran `npx vitest run` and all tests passed (`20 files`, `237 tests` passed). 
- Ran `npx @biomejs/biome lint` and no lint fixes were required. 
- Ran `npm pack --dry-run` to validate packaged files and tarball contents, and the dry-run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343bdbddf08324a59f693556fb1022)